### PR TITLE
Escape label value

### DIFF
--- a/src/Serializer/PrometheusEncoder.php
+++ b/src/Serializer/PrometheusEncoder.php
@@ -47,7 +47,7 @@ class PrometheusEncoder implements EncoderInterface {
     }
     $output = [];
     foreach ($labels as $key => $value) {
-      $output[] = $key . '="' . $value . '"';
+      $output[] = $key . '="' . $this->escapeValue($value) . '"';
     }
     return '{' . implode(',', $output) . '}';
   }


### PR DESCRIPTION
The label values can be like any strange text so this needs to be escaped.

https://github.com/previousnext/php-prometheus/blob/12bf879ed596f6fc2d248cb0b82690640f07e053/src/Serializer/PrometheusEncoder.php#L50

since prometheus does not know any non numeric metric values, the metric value would not need the escape function, but I don't want to break any compatibility. https://github.com/previousnext/php-prometheus/blob/12bf879ed596f6fc2d248cb0b82690640f07e053/src/Serializer/PrometheusEncoder.php#L30

see:
https://github.com/prometheus/prometheus/issues/2227

Best Regards
Nicolas