### PR TITLE
feat: deprecate non-int/float values in Gauge::set()

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,5 +4,9 @@
   <file>./src</file>
   <file>./tests</file>
   <arg name="extensions" value="php"/>
-  <rule ref="Drupal"/>
+  <rule ref="Drupal">
+    <!-- Not a Drupal project: deprecation "See" links point to GitHub issues,
+         not drupal.org change records. -->
+    <exclude name="Drupal.Semantics.FunctionTriggerError.TriggerErrorSeeUrlFormat"/>
+  </rule>
 </ruleset>

--- a/src/Gauge.php
+++ b/src/Gauge.php
@@ -25,11 +25,15 @@ class Gauge extends Metric {
    * Adds a value for this metric.
    *
    * @param mixed $value
-   *   The value.
+   *   The value. Non-int/float values are deprecated.
    * @param array<string, string|int|float> $labels
    *   The list of key value label pairs.
    */
   public function set(mixed $value, array $labels = []): void {
+    if (!is_int($value) && !is_float($value)) {
+      // phpcs:ignore Drupal.Semantics.FunctionTriggerError.TriggerErrorSeeUrlFormat
+      @trigger_error(sprintf('Passing a non-int/float value to %s() is deprecated in php_prometheus:1.1.0 and will throw a \TypeError in php_prometheus:2.0.0. See https://github.com/previousnext/php-prometheus/issues/14', __METHOD__), E_USER_DEPRECATED);
+    }
     $key = $this->getKey($labels);
     $this->labelledValues[$key] = new LabelledValue($this->getName(), $value, $labels);
   }

--- a/src/Gauge.php
+++ b/src/Gauge.php
@@ -31,7 +31,6 @@ class Gauge extends Metric {
    */
   public function set(mixed $value, array $labels = []): void {
     if (!is_int($value) && !is_float($value)) {
-      // phpcs:ignore Drupal.Semantics.FunctionTriggerError.TriggerErrorSeeUrlFormat
       @trigger_error(sprintf('Passing a non-int/float value to %s() is deprecated in php_prometheus:1.1.0 and will throw a \TypeError in php_prometheus:2.0.0. See https://github.com/previousnext/php-prometheus/issues/14', __METHOD__), E_USER_DEPRECATED);
     }
     $key = $this->getKey($labels);

--- a/src/Serializer/PrometheusEncoder.php
+++ b/src/Serializer/PrometheusEncoder.php
@@ -23,7 +23,12 @@ class PrometheusEncoder implements EncoderInterface {
   /**
    * {@inheritdoc}
    *
-   * @phpstan-ignore missingType.iterableValue
+   * @param mixed $data
+   *   The data to encode.
+   * @param string $format
+   *   The encoding format.
+   * @param array<string, mixed> $context
+   *   The serializer context.
    */
   public function encode(mixed $data, string $format, array $context = []): string {
     $output = [];

--- a/tests/Unit/GaugeTest.php
+++ b/tests/Unit/GaugeTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace PNX\Prometheus\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use PNX\Prometheus\Gauge;
 
@@ -43,6 +45,58 @@ class GaugeTest extends TestCase {
   public function testGaugeNoValues(): void {
     $gauge = new Gauge("foo", "bar", "A test gauge");
     $this->assertEmpty($gauge->getLabelledValues());
+  }
+
+  /**
+   * Tests that int and float values are accepted without a deprecation notice.
+   */
+  #[DataProvider('numericValueProvider')]
+  public function testGaugeAcceptsNumericValue(int|float $value): void {
+    $gauge = new Gauge("foo", "bar", "A test gauge");
+    $gauge->set($value);
+
+    $values = $gauge->getLabelledValues();
+    $this->assertCount(1, $values);
+    $this->assertEquals($value, $values[0]->getValue());
+  }
+
+  /**
+   * Provides int and float values accepted by Gauge::set().
+   *
+   * @return array<string, array{int|float}>
+   *   The numeric values to test.
+   */
+  public static function numericValueProvider(): array {
+    return [
+      'integer' => [100],
+      'zero' => [0],
+      'negative integer' => [-5],
+      'float' => [1.5],
+      'negative float' => [-2.75],
+    ];
+  }
+
+  /**
+   * Tests that a non-int/float value triggers a deprecation notice.
+   */
+  public function testGaugeNonNumericValueIsDeprecated(): void {
+    $this->expectUserDeprecationMessage('Passing a non-int/float value to PNX\Prometheus\Gauge::set() is deprecated in php_prometheus:1.1.0 and will throw a \TypeError in php_prometheus:2.0.0. See https://github.com/previousnext/php-prometheus/issues/14');
+
+    $gauge = new Gauge("foo", "bar", "A test gauge");
+    $gauge->set("not-a-number");
+  }
+
+  /**
+   * Tests that a deprecated value is still stored.
+   */
+  #[IgnoreDeprecations]
+  public function testGaugeNonNumericValueIsStored(): void {
+    $gauge = new Gauge("foo", "bar", "A test gauge");
+    @$gauge->set("not-a-number");
+
+    $values = $gauge->getLabelledValues();
+    $this->assertCount(1, $values);
+    $this->assertEquals("not-a-number", $values[0]->getValue());
   }
 
 }


### PR DESCRIPTION
Passing a value that is not an int or float to `Gauge::set()` now triggers an `E_USER_DEPRECATED` notice; values are still stored so behaviour is unchanged. The parameter type will be narrowed to `int|float` in 2.0.0.

Closes #14